### PR TITLE
fix: adds IDE specifics to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,113 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-vendor
 build
 fmt.log
 import.log
+
+# Temporary Files
+bin/
+build/_output
+build/_test
+telepresence.log
+
+# Vendor
+vendor/
+.vendor-new/
+
+### Vim ###
+# swap
+.sw[a-p]
+.*.sw[a-p]
+# session
+Session.vim
+# temporary
+.netrwhist
+# auto-generated tag files
+tags
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+projectile-bookmarks.eld
+
+# directory configuration
+.dir-locals.el
+
+# saveplace
+places
+
+# url cache
+url/cache/
+
+# cedet
+ede-projects.el
+
+# smex
+smex-items
+
+# company-statistics
+company-statistics-cache.el
+
+# anaconda-mode
+anaconda-mode/
+
+### VisualStudioCode ###
+.vscode
+.history
+
+### JetBrains IDEs (Goland) ###
+
+.idea/
+*.iws
+*.ipr
+out/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties


### PR DESCRIPTION
Thanks for putting this tool together. It looks like something I've been thinking of :)

As I'm digging into the code I noticed that `.gitignore` is rather simple and configuration of my IDE of choice might accidentally be added to the repo. So I extended it based on my other project. Might prevent surprises in future contributions.
